### PR TITLE
Make reverse not mutate array

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 const ex = {}
-const arg0 = ['reverse', 'toLowerCase', 'toUpperCase', 'trim']
+const arg0 = ['toLowerCase', 'toUpperCase', 'trim']
 const arg1 = ['concat', 'every', 'filter', 'find', 'findIndex', 'indexOf', 'join', 'map', 'join', 'some', 'sort', 'match', 'split', 'search']
 const arg2 = ['reduce', 'reduceRight', 'replace', 'reduceRight', 'slice']
 
@@ -32,6 +32,7 @@ ex.last = (list) => list[list.length -1]
 ex.length = (list) => list.length
 ex.nth = curry((i, list) => list[i])
 ex.range = curry((start, end) => Array(end - start).fill(1).map((e, i) => i + start))
+ex.reverse = curry(list => [].concat(list).reverse())
 ex.sum = (list) => list.reduce((sum, e) => sum + e, 0)
 ex.tail = (list) => list.slice(1)
 ex.take = curry((i, list) => list.slice(0, i))

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "mocha test.js"
+    "test": "mocha --recursive"
   },
   "author": "",
   "license": "ISC",

--- a/test/compose.js
+++ b/test/compose.js
@@ -1,0 +1,10 @@
+const assert = require('assert')
+const bf = require('../index.js')
+
+describe('compose', () => {
+    it('should run multiple functions in serial', () => {
+        const plus1 = (e) => e + 1
+        const actual = bf.compose(plus1, plus1, plus1, plus1)(1)
+        assert.equal(actual, 5)
+    });
+})

--- a/test/curry.js
+++ b/test/curry.js
@@ -1,0 +1,9 @@
+const assert = require('assert')
+const bf = require('../index.js')
+
+describe('curry', () => {
+    it('should curry the given function', () => {
+        const add = bf.curry((a, b) => a + b)
+        assert.equal(add(1)(2), add(1, 2))
+    });
+})

--- a/test/reverse.js
+++ b/test/reverse.js
@@ -1,0 +1,15 @@
+const assert = require('assert')
+const bf = require('../index.js')
+
+describe('compose', () => {
+
+    it('should reverse list', () => {
+        const list = [1, 2, 3, 4, 5]
+        assert.deepEqual(bf.reverse(list), [5, 4, 3, 2, 1])
+    })
+
+    it('should not mutate argument', () => {
+        const list = [1, 2, 3, 4, 5]
+        assert.notEqual(bf.reverse(list), list)
+    })
+})


### PR DESCRIPTION
The native `reverse` function updates the array in place.

Mutating users' data is bad, very, very bad. We should not do this.

We no longer this.