### PR TITLE
Support objects created with Object.create(null) in _.has

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,10 +4,12 @@ const arg0 = ['toLowerCase', 'toUpperCase', 'trim']
 const arg1 = ['concat', 'every', 'filter', 'find', 'findIndex', 'indexOf', 'join', 'map', 'some', 'match', 'split']
 const arg2 = ['reduce', 'reduceRight', 'replace', 'reduceRight', 'slice']
 
+const slice = Array.prototype.slice
+
 const curry = ex.curry = (f) => function () {
   let args = []
   const curried = function () {
-    args = args.concat(Array.prototype.slice.call(arguments))
+    args = args.concat(slice.call(arguments))
     return (args.length >= f.length) ? f.apply(null, args) : curried
   }
   return curried.apply(null, arguments)
@@ -41,15 +43,15 @@ ex.take = curry((i, list) => list.slice(0, i))
 ex.test = curry((regex, string) => string.search(regex) !== -1)
 ex.merge = curry((o, o1) => ex.mergeAll([o, o1]))
 ex.mergeAll = list => Object.assign.apply(null, [{}].concat(list))
-ex.has = curry((prop, o) => o.hasOwnProperty(prop))
+ex.has = curry((prop, o) => Object.prototype.hasOwnProperty.call(o, prop))
 ex.keys = o => Object.keys(o)
 ex.values = o => Object.keys(o).map((k) => o[k])
 ex.prop = curry((prop, o) => o[prop])
 ex.props = curry((props, o) => props.map(p => o[p]))
 ex.compose = function () {
-  const fs = Array.prototype.slice.call(arguments).reverse()
+  const fs = slice.call(arguments).reverse()
   return function () {
-    const args = Array.prototype.slice.call(arguments)
+    const args = slice.call(arguments)
     return ex
       .tail(fs)
       .reduce((arg, f) => f(arg), ex.head(fs).apply(null, args))

--- a/test/has.js
+++ b/test/has.js
@@ -1,0 +1,17 @@
+const assert = require('assert')
+const bf = require('../index.js')
+
+describe('has', () => {
+
+  it('should return if the specified key is in an object', () => {
+    const obj = {a: 1, b: 2, c: 3}
+    assert.strictEqual(bf.has('a', obj), true)
+  })
+
+  it('should return if the specified key is in an object create with Object.create(null)', () => {
+    const obj = Object.create(null)
+    obj.a = 1
+    assert.strictEqual(bf.has('a', obj), true)
+  })
+
+})


### PR DESCRIPTION
Currently `has` fails for objects created with `Object.create(null)` because those objects down have an `hasOwnProperties` method. I also pulled out the native `slice` function into its own variable to make up for the bytes I've added. ;)