### PR TITLE
Only invoke map's callback with a single argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,8 @@ _.length([1, 2, 3])
 ```
 
 ### map :: (a -> b) -> [a] -> [b]
-Returns a new list, constructed by applying the supplied function to every element of the supplied list.
+Returns a new list, constructed by applying the supplied unary function to every 
+element of the supplied list.
 
 ```js
 _.map(n => n + 1, [1, 2, 3])

--- a/map.js
+++ b/map.js
@@ -1,3 +1,3 @@
 const curry = require('./curry')
 
-module.exports = curry((f, xs) => xs.map(f))
+module.exports = curry((f, xs) => xs.map(x => f(x)))

--- a/test/map.js
+++ b/test/map.js
@@ -19,6 +19,10 @@ describe('map', () => {
     assert.deepEqual(map(inc, [1, 2, 3, 4, 5, 6]), [2, 3, 4, 5, 6, 7])
   })
 
+  it('should only use only one argument when invoking the provided mapping function', () => {
+    assert.deepEqual(map(parseInt, ['1', '2', '3', '4', '5']), [1, 2, 3, 4, 5])
+  })
+
   it('is exported from index', () => {
     assert.deepEqual(bf.map(inc, [1, 2, 3, 4, 5, 6]), [2, 3, 4, 5, 6, 7])
   })


### PR DESCRIPTION
Because the native `map` function does not obey the functor laws it means it is possible to pass a function with accepts more than one argument as the callback. This can result in surprising output:

```js
bf.map(parseInt, ['1', '2', '3'])
// => [ 1, NaN, NaN ]
```

The solution is to explicitly invoke the supplied callback with only one argument.