### PR TITLE
Fix argument persistence bug in curry

### DIFF
--- a/curry.js
+++ b/curry.js
@@ -1,10 +1,12 @@
-'use strict'
-
-module.exports = (f) => function () {
-  let args = []
-  const curried = function () {
-    args = args.concat(Array.prototype.slice.call(arguments))
-    return (args.length >= f.length) ? f.apply(null, args) : curried
+const curry = (f, args=[]) => {
+  function curried() {
+    const nextArgs = args.concat(Array.prototype.slice.call(arguments))
+    return (nextArgs.length === f.length) 
+      ? f.apply(null, nextArgs)
+      : curry(f, nextArgs)
   }
-  return curried.apply(null, arguments)
+
+  return curried
 }
+
+module.exports = curry

--- a/test/curry.js
+++ b/test/curry.js
@@ -14,4 +14,11 @@ describe('curry', () => {
         assert.equal(add(1)(2), add(1, 2))
     })
 
+    it('should not persist arguments between calls', () => {
+      const add = bf.curry((a, b) => a + b)
+      const add10 = add(10)
+      const add1 = add(1)
+      assert.equal(add10(10), 20)
+      assert.equal(add1(1), 2)
+    })
 })


### PR DESCRIPTION
By calling curry again with the new args, we avoid relying on mutation
to represent the fact that we have new args. That is, each time new args
are added, we either return a brand new curried function or we call the
function with the args that are present.